### PR TITLE
Fix compilation under PHP 7.3

### DIFF
--- a/php_bbcode.c
+++ b/php_bbcode.c
@@ -400,11 +400,19 @@ static PHP_FUNCTION(bbcode_create)
                 if (key && data != NULL) {
 					tmp_ht = HASH_OF(data);
 					if (tmp_ht) {
+#if PHP_VERSION_ID >= 70300
+						GC_PROTECT_RECURSION(tmp_ht);
+#else
 						tmp_ht->u.v.nApplyCount++;
+#endif
 					}
 					_php_bbcode_add_element(parser, ZSTR_VAL(key), ZSTR_LEN(key), data TSRMLS_CC);
 					if (tmp_ht) {
-							tmp_ht->u.v.nApplyCount--;
+#if PHP_VERSION_ID >= 70300
+						GC_UNPROTECT_RECURSION(tmp_ht);
+#else
+						tmp_ht->u.v.nApplyCount--;
+#endif
 					}
 				}
 			} ZEND_HASH_FOREACH_END();


### PR DESCRIPTION
`nApplyCount` was removed from PHP 7.3, and as a result this fails to build with the following error:

```
php_pecl_bbcode/php_bbcode.c: In function ‘zif_bbcode_create’:
php_pecl_bbcode/php_bbcode.c:403:18: error: ‘struct <anonymous>’ has no member named ‘nApplyCount’
               tmp_ht->u.v.nApplyCount++;
                          ^
php_pecl_bbcode/php_bbcode.c:407:19: error: ‘struct <anonymous>’ has no member named ‘nApplyCount’
                tmp_ht->u.v.nApplyCount--;
                           ^
make: *** [Makefile:193: php_bbcode.lo] Error 1
```

This PR allows the build to function. The change is modeled after https://github.com/php/pecl-file_formats-yaml/pull/33.